### PR TITLE
Add the ability to export to features

### DIFF
--- a/block_islandora_options.features.inc
+++ b/block_islandora_options.features.inc
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Implements hook_features_export_options().
+ */
+function block_islandora_options_config_features_export_options() {
+  $field_types = array(
+    'all_options' => t('All Islandora Block Options.'),
+  );
+  return $field_types;
+}
+
+/**
+ * Implements hook_features_export().
+ */
+function block_islandora_options_config_features_export($data, &$export, $module_name = '') {
+  $export['dependencies']['block_islandora_options'] = 'block_islandora_options';
+
+  foreach ($data as $component) {
+    $export['features']['block_islandora_options_config'][$component] = $component;
+  }
+}
+
+/**
+ * Implements hook_features_export_render().
+ */
+function block_islandora_options_config_features_export_render($module_name, $data, $export = NULL) {
+  $code = array();
+  if (in_array('all_options', $data)) {
+    $code = block_islandora_options_all_options();
+  }
+  $code = '  return ' . features_var_export($code) . ';';
+  return array('block_islandora_options_config_features_default_settings' => $code);
+}
+
+/**
+ * Implements hook_features_revert().
+ */
+function block_islandora_options_config_features_revert($module) {
+  block_islandora_options_config_features_rebuild($module);
+}
+
+/**
+ * Implements hook_features_rebuild().
+ */
+function block_islandora_options_config_features_rebuild($module) {
+  $items = module_invoke($module, 'block_islandora_options_config_features_default_settings');
+  if (!empty($items)) {
+    db_delete('block_islandora_options')->execute();
+  }
+
+  foreach ($items as $item) {
+    $opt = new stdClass;
+    $opt->module = $item['module'];
+    $opt->delta = $item['delta'];
+    $opt->cmodel = $item['cmodel'];
+    block_islandora_options_save_option($opt);
+  }
+}

--- a/block_islandora_options.install
+++ b/block_islandora_options.install
@@ -13,6 +13,12 @@ function block_islandora_options_schema() {
   $schema['block_islandora_options'] = array(
     'description' => 'Sets up display criteria for blocks based on Islandora context',
     'fields' => array(
+      'oid' => array(
+        'type' => 'serial',
+        'length' => 12,
+        'not null' => TRUE,
+        'description' => "Unique ID for this table",
+      ),
       'module' => array(
         'type' => 'varchar',
         'length' => 64,
@@ -32,11 +38,26 @@ function block_islandora_options_schema() {
         'description' => "The cmodel name of this type from islandora.",
       ),
     ),
-    'primary key' => array('module', 'delta', 'cmodel'),
+    'primary key' => array('oid'),
     'indexes' => array(
       'status' => array('cmodel'),
+    ),
+    'unique keys' => array(
+      'block' => array('module', 'delta', 'cmodel'),
     ),
   );
 
   return $schema;
+}
+
+/**
+ * Add the oid column
+ */
+function block_islandora_options_update_7100() {
+  if (!db_field_exists("block_islandora_options", "oid")) {
+    $schema = block_islandora_options_schema();
+    db_drop_primary_key('block_islandora_options');
+    db_add_field('block_islandora_options', "oid", $schema['block_islandora_options']['fields']['oid'], array('primary key' => array('oid')));
+    db_add_unique_key('block_islandora_options', 'block', array('module', 'delta', 'cmodel'));
+  }
 }

--- a/block_islandora_options.module
+++ b/block_islandora_options.module
@@ -64,15 +64,26 @@ function block_islandora_options_form_block_admin_configure_submit($form, &$form
     ->execute();
   if (count($form_state['values']['islandora_cmodels_status']) > 0) {
     foreach (array_filter($form_state['values']['islandora_cmodels_status']) as $pid) {
-      db_insert('block_islandora_options')
-        ->fields(array(
-          'cmodel' => $pid,
-          'module' => $form_state['values']['module'],
-          'delta' => $form_state['values']['delta'],
-        ))
-        ->execute();
+      $opt = new stdClass;
+      $opt->cmodel = $pid;
+      $opt->module = $form_state['values']['module'];
+      $opt->delta = $form_state['values']['delta'];
+      block_islandora_options_save_option($opt);
     }
   }
+}
+
+/**
+ * Add the passed option to the database.
+ */
+function block_islandora_options_save_option($opt) {
+  db_insert('block_islandora_options')
+    ->fields(array(
+      'cmodel' => $opt->cmodel,
+      'module' => $opt->module,
+      'delta' => $opt->delta,
+    ))
+    ->execute();
 }
 
 /**
@@ -107,4 +118,30 @@ function block_islandora_options_block_list_alter(&$blocks) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_features_api().
+ */
+function block_islandora_options_features_api() {
+  return array(
+    'block_islandora_options_config' => array(
+      'name' => 'Islandora block options config',
+      'file' => drupal_get_path('module', 'block_islandora_options') . '/block_islandora_options.features.inc',
+      'default_hook' => 'block_islandora_options_config_features_default_settings',
+      'feature_source' => TRUE,
+    ),
+  );
+}
+
+/**
+ * Returns all options.
+ */
+function block_islandora_options_all_options() {
+  $opts = db_select('block_islandora_options', 'bio')
+    ->fields('bio')
+    ->orderBy('oid', 'ASC')
+    ->execute()
+    ->fetchAllAssoc('oid');
+  return $opts;
 }


### PR DESCRIPTION
This PR will add some initial features export capability. It exposes a single option, "All Islandora block options", which can be exported and will include all configured Islandora block options.

To enable this, I had to add a new primary key column, which should get correctly added when running a database update. To ensure that the module-delta-cmodel key still maintains a consistent database, I've added it as a unique key instead of the primary key.

I don't explicitly declare the Features dependency so there are no additional dependencies to use this module normally, but if features is available then it will have the additional functionality.
